### PR TITLE
Add published URL feature

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <artifactId>ghprb</artifactId>
     <name>github pull requests builder</name>
-    <version>1.2</version>
+    <version>1.2.pub</version>
     <packaging>hpi</packaging>
 
     <url>https://wiki.jenkins-ci.org/display/JENKINS/Github+pull+request+builder+plugin</url>

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbRepo.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbRepo.java
@@ -79,7 +79,7 @@ public class GhprbRepo {
 	private void checkBuilds() throws IOException{
 		Iterator<Entry<Integer, QueueTaskFuture<?>>> it;
 		it = queuedBuilds.entrySet().iterator();
-		while(it.hasNext()){
+		 while(it.hasNext()){
 			Entry<Integer, QueueTaskFuture<?>> e =it.next();
 			if(e.getValue().getStartCondition().isDone()){
 				it.remove();
@@ -114,6 +114,10 @@ public class GhprbRepo {
 					state = GHCommitState.FAILURE;
 				}
 				createCommitStatus(build, state, "Build finished");
+				String publishedURL = trigger.getDescriptor().getPublishedURL();
+				if (publishedURL != null) {
+					addComment(e.getKey(), "Build results will soon be (or already are) available at: " + publishedURL + build.getUrl());
+				}
 			}
 		}
 	}

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
@@ -115,6 +115,7 @@ public final class GhprbTrigger extends Trigger<AbstractProject<?, ?>> {
 		private String username;
 		private String password;
 		private String adminlist;
+		private String publishedURL;
 		private String whitelistPhrase;
 		private String retestPhrase;
 		private String cron;
@@ -145,6 +146,7 @@ public final class GhprbTrigger extends Trigger<AbstractProject<?, ?>> {
 			username = formData.getString("username");
 			password = formData.getString("password");
 			adminlist = formData.getString("adminlist");
+                        publishedURL = formData.getString("publishedURL");
 			whitelistPhrase = formData.getString("whitelistPhrase");
 			retestPhrase = formData.getString("retestPhrase");
 			cron = formData.getString("cron");
@@ -177,6 +179,10 @@ public final class GhprbTrigger extends Trigger<AbstractProject<?, ?>> {
 
 		public String getAdminlist() {
 			return adminlist;
+		}
+
+		public String getPublishedURL() {
+			return publishedURL;
 		}
 
 		public String getWhitelistPhrase() {

--- a/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/global.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/global.jelly
@@ -10,8 +10,11 @@
       <f:textarea />
     </f:entry>
     <f:advanced>
-	  <f:entry title="${%Add to white list phrase}" field="whitelistPhrase">
-	    <f:textbox default=".*ok\W+to\W+test.*"/>
+      <f:entry title="${%Published Jenkins URL}" field="publishedURL">
+        <f:textbox/>
+      </f:entry>
+      <f:entry title="${%Add to white list phrase}" field="whitelistPhrase">
+        <f:textbox default=".*ok\W+to\W+test.*"/>
       </f:entry>
       <f:entry title="${%Retest phrase}" field="retestPhrase">
         <f:textbox default=".*retest\W+this\W+please.*"/>


### PR DESCRIPTION
In my situation the Jenkins server is not public but we publish results to a public one, with the build publisher plugin.

I would like to be able to point to the URL of published results like it's done here:
https://github.com/jbossas/jboss-as/pull/3119
It helps to see the result even though they won't be able to see the work in progress.

I added this parameter in the config screen, and just added a link to the public instance in a new comment...

You would not want to pick the pom.xml change from that PR.

Thanks for this awesome plugin BTW.
