### PR TITLE
Prevent NullPointerException due to missing url

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
@@ -62,6 +62,10 @@ public final class GhprbTrigger extends Trigger<AbstractProject<?, ?>> {
 		}
 		
 		GithubProjectProperty ghpp = project.getProperty(GithubProjectProperty.class);
+		if(ghpp.getProjectUrl() == null) {
+			Logger.getLogger(GhprbTrigger.class.getName()).log(Level.WARNING, "A github project url is required.");
+			return;
+		}
 		Matcher m = githubUserRepoPattern.matcher(ghpp.getProjectUrl().baseUrl());
 		if(!m.matches()) {
 			Logger.getLogger(GhprbTrigger.class.getName()).log(Level.WARNING, "Invalid github project url: " + ghpp.getProjectUrl().baseUrl());


### PR DESCRIPTION
If no github url is supplied and the user tries to save/apply the configuration file they will get a NullPointerException. Check if the GithubProjectProperty class instance is not null before trying to call methods on it.
