### PR TITLE
Actual SHA of latest commit on branch isn't available.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
@@ -98,13 +98,14 @@ public final class GhprbTrigger extends Trigger<AbstractProject<?, ?>> {
 	}
 
 	public QueueTaskFuture<?> startJob(GhprbCause cause){
+		StringParameterValue paramGhprbActualCommit = new StringParameterValue("ghprbActualCommit",cause.getCommit());
 		StringParameterValue paramSha1;
 		if(cause.isMerged()){
 			paramSha1 = new StringParameterValue("sha1","origin/pr/" + cause.getPullID() + "/merge");
 		}else{
 			paramSha1 = new StringParameterValue("sha1",cause.getCommit());
 		}
-		return this.job.scheduleBuild2(0,cause,new ParametersAction(paramSha1));
+		return this.job.scheduleBuild2(0,cause,new ParametersAction(paramSha1,paramGhprbActualCommit));
 	}
 
 	@Override


### PR DESCRIPTION
Because Jenkins tests by merging pull requests into master, the `GIT_COMMIT` environment variable represents the commit that resulted from the merge Jenkins did, not the commit that triggered the build. It would be helpful for the commit that triggered the build to be available in some environment variable instead of trying to calculate it from the git history.
