### PR TITLE
Fix bug where default parameter values on a parameterized build are ignored

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
@@ -102,7 +102,6 @@ public final class GhprbTrigger extends Trigger<AbstractProject<?, ?>> {
 	}
 
 	public QueueTaskFuture<?> startJob(GhprbCause cause){
-		StringParameterValue paramSha1;
 		ArrayList<ParameterValue> values = getDefaultParameters();
 		if(cause.isMerged()){
 			values.add(new StringParameterValue("sha1","origin/pr/" + cause.getPullID() + "/merge"));


### PR DESCRIPTION
I noticed that when a new build is scheduled by ghprb on a parameterized build, the only parameter on the build is "sha1". All the other parameters are ignored. This bug is essentially identical to the following Jenkins bug, and the fix is the same: https://issues.jenkins-ci.org/browse/JENKINS-7162
