### PR TITLE
Repo url no longer assumes https

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbRepo.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbRepo.java
@@ -241,7 +241,7 @@ public class GhprbRepo {
 	}
 
 	public String getRepoUrl(){
-		return "https://"+githubServer+"/"+reponame;
+		return githubServer+"/"+reponame;
 	}
 
 	private boolean isInWhitelistedOrganisation(String username) {

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
@@ -47,7 +47,7 @@ public final class GhprbTrigger extends Trigger<AbstractProject<?, ?>> {
 	transient         HashSet<String>                whitelisted;
 	transient         HashSet<String>                organisations;
 
-	private static final Pattern githubUserRepoPattern = Pattern.compile("^http[s]?://([^/]*)/([^/]*)/([^/]*).*");
+	private static final Pattern githubUserRepoPattern = Pattern.compile("^(http[s]?://[^/]*)/([^/]*)/([^/]*).*");
 
 	@DataBoundConstructor
 	public GhprbTrigger(String adminlist, String whitelist, String orgslist, String cron) throws ANTLRException{


### PR DESCRIPTION
My repo url is not https, and the old way was assuming that it was.  This now pulls in the http(s) from the github url to be use later as the repo url.
