### PR TITLE
Fixes: Global config and github-api versioning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,12 +42,12 @@
         <dependency>
             <groupId>com.coravy.hudson.plugins.github</groupId>
             <artifactId>github</artifactId>
-            <version>1.4</version>
+            <version>1.5</version>
         </dependency>
         <dependency>
-            <groupId>org.kohsuke</groupId>
+            <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>github-api</artifactId>
-            <version>1.35</version>
+            <version>1.34</version>
         </dependency>
     </dependencies>
 

--- a/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/global.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/global.jelly
@@ -16,8 +16,8 @@
       <f:textarea />
     </f:entry>
     <f:advanced>
-      <f:entry title="Mark Unstable build in github as" field="unstableAs">
-        <select>
+      <f:entry name="unstableAs" title="Mark Unstable build in github as" field="unstableAs">
+        <select name="unstableAs">
           <option value="FAILURE">Failure</option>
           <option value="SUCCESS">Success</option>
           <option value="ERROR">Error</option>


### PR DESCRIPTION
### Description
- Setting the plugin's global configuration was failing due to not being able to extract the form data for `unstableAs`. It is now fixed.
- There was a version conflict between `com.coravy.hudson.plugins.github.github 1.4` and the plugin that was directly depending on `org.jenkins-ci.plugins.github-api 1.35`. `github 1.4` has a transitive dependency on `github-api 1.28`. Jenkins picks up the **v1.28 instead of v1.35** which breaks some of the API calls. Changed according to suggestion found [here](https://wiki.jenkins-ci.org/display/JENKINS/GitHub+API+Plugin) so as not to embed the github-api jar and also fix the versioning issue.
