### PR TITLE
Decorate commit status messages and honour quiet period.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbBuilds.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbBuilds.java
@@ -24,29 +24,16 @@ public class GhprbBuilds {
 		this.repo = repo;
 	}
 
-	public String build(GhprbPullRequest pr) {
-		StringBuilder sb = new StringBuilder();
-		if(cancelBuild(pr.getId())){
-			sb.append("Previous build stopped.");
-		}
-
-		if(pr.isMergeable()){
-			sb.append(" Merged build triggered.");
-		}else{
-			sb.append(" Build triggered.");
-		}
+	public void build(GhprbPullRequest pr) {
+		String message = pr.isMergeable() ? "Merged build triggered" : " Build triggered";
+		repo.createCommitStatus(pr.getHead(), GHCommitState.PENDING, null, message, pr.getId());
 
 		GhprbCause cause = new GhprbCause(pr.getHead(), pr.getId(), pr.isMergeable(), pr.getTarget(), pr.getAuthorEmail(), pr.getTitle());
-
 		QueueTaskFuture<?> build = trigger.startJob(cause);
-		if(build == null){
+
+		if (build == null) {
 			logger.log(Level.SEVERE, "Job did not start");
 		}
-		return sb.toString();
-	}
-
-	private boolean cancelBuild(int id) {
-		return false;
 	}
 
 	private GhprbCause getCause(AbstractBuild build){
@@ -59,7 +46,9 @@ public class GhprbBuilds {
 		GhprbCause c = getCause(build);
 		if(c == null) return;
 
-		repo.createCommitStatus(build, GHCommitState.PENDING, (c.isMerged() ? "Merged build started." : "Build started."),c.getPullID());
+		String message = String.format("%s #%d started", c.isMerged() ? "Merged build" : "Build", build.getNumber());
+		repo.createCommitStatus(build, GHCommitState.PENDING, message, c.getPullID());
+
 		try {
 			build.setDescription("<a title=\"" + c.getTitle() + "\" href=\"" + repo.getRepoUrl()+"/pull/"+c.getPullID()+"\">PR #"+c.getPullID()+"</a>: " + c.getAbbreviatedTitle());
 		} catch (IOException ex) {
@@ -72,14 +61,24 @@ public class GhprbBuilds {
 		if(c == null) return;
 
 		GHCommitState state;
+		String verb;
 		if (build.getResult() == Result.SUCCESS) {
 			state = GHCommitState.SUCCESS;
-		} else if (build.getResult() == Result.UNSTABLE){
-			state = GHCommitState.valueOf(GhprbTrigger.getDscp().getUnstableAs());
-		} else {
-			state = GHCommitState.FAILURE;
+			verb = "succeeded";
 		}
-		repo.createCommitStatus(build, state, (c.isMerged() ? "Merged build finished." : "Build finished."),c.getPullID() );
+		else if (build.getResult() == Result.UNSTABLE) {
+			state = GHCommitState.valueOf(GhprbTrigger.getDscp().getUnstableAs());
+			verb = "found unstable";
+		}
+		else {
+			state = GHCommitState.FAILURE;
+			verb = "failed";
+		}
+
+		String message =
+				String.format("%s #%d %s in %s", c.isMerged() ? "Merged build" : "Build", build.getNumber(), verb,
+						build.getDurationString());
+		repo.createCommitStatus(build, state, message, c.getPullID());
 
 		String publishedURL = GhprbTrigger.getDscp().getPublishedURL();
 		if (publishedURL != null && !publishedURL.isEmpty()) {

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbPullRequest.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbPullRequest.java
@@ -4,7 +4,7 @@ import java.io.IOException;
 import java.util.Date;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import org.kohsuke.github.GHCommitState;
+
 import org.kohsuke.github.GHIssueComment;
 import org.kohsuke.github.GHPullRequest;
 
@@ -110,18 +110,10 @@ public class GhprbPullRequest{
 			shouldRun = false;
 		}
 		if (shouldRun) {
-			build();
-			shouldRun = false;
+            ml.getBuilds().build(this);
+            shouldRun = false;
 			triggered = false;
 		}
-	}
-
-	private void build(){
-		String message = ml.getBuilds().build(this);
-
-		repo.createCommitStatus(head, GHCommitState.PENDING, null, message,id);
-
-		logger.log(Level.INFO, message);
 	}
 
 	// returns false if no new commit

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
@@ -110,7 +110,7 @@ public final class GhprbTrigger extends Trigger<AbstractProject<?, ?>> {
 		// it's possible the GHUser doesn't have an associated email address
 		values.add(new StringParameterValue("ghprbPullAuthorEmail",cause.getAuthorEmail() != null ? cause.getAuthorEmail() : ""));
 
-		return this.job.scheduleBuild2(0,cause,new ParametersAction(values));
+		return job.scheduleBuild2(job.getQuietPeriod(), cause, new ParametersAction(values));
 	}
 
 	private ArrayList<ParameterValue> getDefaultParameters() {


### PR DESCRIPTION
The quiet period also provides a workaround for GitHub timing issues: sometimes GitHub will show the 'build triggered' message even though the 'build started' message was sent shortly after.
