### PR TITLE
Fix "spread load evenly" warning

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/global.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/global.jelly
@@ -39,7 +39,7 @@
         <f:textbox default=".*test\W+this\W+please.*"/>
       </f:entry>
       <f:entry title="${%Crontab line}" field="cron">
-        <f:textbox default="*/5 * * * *"/>
+        <f:textbox default="H/5 * * * *"/>
       </f:entry>
       <f:entry title="${%Default success message}" field="msgSuccess">
         <f:textarea default="Test PASSed."/>


### PR DESCRIPTION
H/5 does the same as */5 but avoids the warning by Jenkins.
