### PR TITLE
Adds GitHub user email as a parameter and updates description for job

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbBuilds.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbBuilds.java
@@ -36,7 +36,7 @@ public class GhprbBuilds {
 			sb.append(" Build triggered.");
 		}
 
-		GhprbCause cause = new GhprbCause(pr.getHead(), pr.getId(), pr.isMergeable(), pr.getTarget());
+		GhprbCause cause = new GhprbCause(pr.getHead(), pr.getId(), pr.isMergeable(), pr.getTarget(), pr.getAuthorEmail(), pr.getTitle());
 
 		QueueTaskFuture<?> build = trigger.startJob(cause);
 		if(build == null){
@@ -61,7 +61,7 @@ public class GhprbBuilds {
 
 		repo.createCommitStatus(build, GHCommitState.PENDING, (c.isMerged() ? "Merged build started." : "Build started."),c.getPullID());
 		try {
-			build.setDescription("<a href=\"" + repo.getRepoUrl()+"/pull/"+c.getPullID()+"\">Pull request #"+c.getPullID()+"</a>");
+			build.setDescription("<a title=\"" + c.getTitle() + "\" href=\"" + repo.getRepoUrl()+"/pull/"+c.getPullID()+"\">PR #"+c.getPullID()+"</a>: " + c.getAbbreviatedTitle());
 		} catch (IOException ex) {
 			logger.log(Level.SEVERE, "Can't update build description", ex);
 		}

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbCause.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbCause.java
@@ -1,5 +1,7 @@
 package org.jenkinsci.plugins.ghprb;
 
+import org.apache.commons.lang.StringUtils;
+
 import hudson.model.Cause;
 
 /**
@@ -10,12 +12,16 @@ public class GhprbCause extends Cause{
 	private final int pullID;
 	private final boolean merged;
 	private final String targetBranch;
+	private final String authorEmail;
+	private final String title;
 
-	public GhprbCause(String commit, int pullID, boolean merged, String targetBranch){
+	public GhprbCause(String commit, int pullID, boolean merged, String targetBranch, String authorEmail, String title){
 		this.commit = commit;
 		this.pullID = pullID;
 		this.merged = merged;
 		this.targetBranch = targetBranch;
+		this.authorEmail = authorEmail;
+		this.title = title;
 	}
 
 	@Override
@@ -38,4 +44,26 @@ public class GhprbCause extends Cause{
 	public String getTargetBranch() {
 		return targetBranch;
 	}
+
+	public String getAuthorEmail() {
+		return authorEmail;
+	}
+
+	/**
+	 * Returns the title of the cause, not null.
+	 * @return
+	 */
+	public String getTitle() {
+		return title != null ? title : "";
+	}
+
+	/**
+	 * Returns at most the first 30 characters of the title, or 
+	 * @return
+	 */
+	public String getAbbreviatedTitle() {
+		return StringUtils.abbreviate(getTitle(), 30);
+	}
+	
+	
 }

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
@@ -105,6 +105,8 @@ public final class GhprbTrigger extends Trigger<AbstractProject<?, ?>> {
 		values.add(new StringParameterValue("ghprbActualCommit",cause.getCommit()));
 		values.add(new StringParameterValue("ghprbPullId",String.valueOf(cause.getPullID())));
 		values.add(new StringParameterValue("ghprbTargetBranch",String.valueOf(cause.getTargetBranch())));
+		// it's possible the GHUser doesn't have an associated email address
+		values.add(new StringParameterValue("ghprbPullAuthorEmail",cause.getAuthorEmail() != null ? cause.getAuthorEmail() : ""));
 
 		return this.job.scheduleBuild2(0,cause,new ParametersAction(values));
 	}


### PR DESCRIPTION
The pull requester's email address is now added as a job parameter, if the
GitHub user has set it on their public profile.
The job description now includes the title of the pull request.
