### PR TITLE
set insecure_ssl to webhook config

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbRepository.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbRepository.java
@@ -8,6 +8,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.HashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.model.Jenkins;
@@ -170,7 +171,10 @@ public class GhprbRepository {
 		}
 		try {
 			if(hookExist()) return true;
-			repo.createWebHook(new URL(ml.getHookUrl()),EVENTS);
+			Map<String, String> config = new HashMap<String, String>();
+			config.put("url", new URL(ml.getHookUrl()).toExternalForm());
+			config.put("insecure_ssl", "1");
+			repo.createHook("web", config, EVENTS, true);
 			return true;
 		}catch(IOException ex){
 			logger.log(


### PR DESCRIPTION
Without `insecure_ssl`, sites which use https with self-hosted cert can't receive
`pull_request` web hook.
the option is also set to `"1"` when adding webhook URL via GitHub Web UI.
