### PR TITLE
Fixes issue where we are unable to get the author email on triggers

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbPullRequest.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbPullRequest.java
@@ -219,7 +219,7 @@ public class GhprbPullRequest{
 	private void obtainAuthorEmail(GHPullRequest pr) {
 		try {
 			authorEmail = pr.getUser().getEmail();
-		} catch (IOException e) {
+		} catch (Exception e) {
 			logger.log(Level.WARNING, "Couldn't obtain author email.", e);
 		}
 	}


### PR DESCRIPTION
Sometimes the GitHub API throws a NPE when attempting to get the user for
a PR; this information is optional and shouldn't cause the trigger to
fail.
