### PR TITLE
update web hook doc to include trailing slash

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/help-useGitHubHooks.html
+++ b/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/help-useGitHubHooks.html
@@ -5,6 +5,6 @@
 	admin rights to specified repository.<br/>
 	If you want to create hook manualy set it for event types:
 		<code>issue_comment</code>,	<code>pull_request</code>
-	and url <code>http://yourserver.com/jenkins/ghprbhook</code>.<br/>
+	and url <code>http://yourserver.com/jenkins/ghprbhook/</code>.<br/>
 	Also your Jenkins server must be accessible from internet.
 </div>


### PR DESCRIPTION
When using a URL without a trailing slash GitHub reports a http status code 302 from Jenkins and no trigger message appears in the Jenkins log.

With a trailing slash the web hook reports a status 200 and the Jenkins log shows the trigger event, e.g.:

```
<timestamp> INFO org.jenkinsci.plugins.ghprb.GhprbRootAction doIndex
Got payload event: issue_comment
```

Since the trailing slash seems to be crucial the tool tip should actually include it.
