### PR TITLE
could not get it to create the webhook

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/Ghprb.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/Ghprb.java
@@ -192,6 +192,7 @@ public class Ghprb {
 			gml.repository = new GhprbRepository(user, repo, gml,pulls);
 			gml.repository.init();
 			if(gml.trigger.getUseGitHubHooks()){
+				gml.repository.checkState();
 				gml.repository.createHook();
 			}
 			gml.builds = new GhprbBuilds(gml.trigger,gml.repository);

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbRepository.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbRepository.java
@@ -51,7 +51,7 @@ public class GhprbRepository {
 		}
 	}
 
-    private boolean checkState() {
+    public boolean checkState() {
         GitHub gitHub = null;
         try {
             gitHub = ml.getGitHub().get();


### PR DESCRIPTION
I have the latest version of the plugin (1.11.2) installed (using Jenkins 1.551).
In the global configuration under "GitHub pull requests builder" I have:
- `GitHub server api URL`: https://api.github.com
- `Access token`: xxxxx (for a separate user with the following scopes for the access token: `repo` and `admin:repo_hook`)
- `Admin list`: for now the user name owning the access token
- `Published Jenkins URL`: http url to the public Jenkins server

On the job side I have:
- `GitHub project`: http://github.com/ros/test_jenkins_pull_request_integration (tried https and/or `.git` suffix here already)
- Checked `This build is parameterized` with a string parameter `sha1`
- Added the Git repository information: url, refspec, branch specifier
- Checked `GitHub pull requests builder` with the following configuration:
  - `Admin list`: for now the same user name as above
  - Checked `Use github hooks for build triggering`

Every time when I save the job GHPRB tries to create the webhook but seems to fail. The Jenkins log contains the following:

```
<timestamp> INFO org.jenkinsci.plugins.ghprb.GhprbRepository createHook
Repository not available, cannot set pull request hook for repository ros/test_jenkins_pull_request_integration
<timestamp> INFO org.jenkinsci.plugins.ghprb.GhprbTrigger start
Starting trigger
```

I triple checked the repo name/url and it is correct. The Jenkins job has even the "GitHub" link in the sidebar of the job which point to the repo.

Any help would be appreciated.
## 

The following is just a brain dump from me briefly looking at the code and getting confused how it works (and trying to figure out what I might have done wrong).

I seem to run into this error message: https://github.com/janinko/ghprb/blob/1a859f74fd5b9fade80bdd2e78e7c7d4f04f4d00/src/main/java/org/jenkinsci/plugins/ghprb/GhprbRepository.java#L194 which indicates that the member var `repo` from a `GhprbRepository` instance is `null`.

The method `createHook` seems to be only called from https://github.com/janinko/ghprb/blob/1a859f74fd5b9fade80bdd2e78e7c7d4f04f4d00/src/main/java/org/jenkinsci/plugins/ghprb/Ghprb.java#L197.

The `GhprbRepository` instance used there is only constructed and then `init()` is invoked on it (the lines directly above).

But it looked like to me that `check()` needs to be called on the `GhprbRepository` instance since `checkState()` (which is called internally) is the only location where the member variable `repo` get set to something else then null.

But since these code parts weren't changed for a quite some time and others have obviously made it work before my code reading might just be completely off...
