### PR TITLE
improve handling of issue comment hook

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbRepository.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbRepository.java
@@ -224,6 +224,12 @@ public class GhprbRepository {
 		if(!"created".equals(issueComment.getAction())) return;
 		GhprbPullRequest pull = pulls.get(id);
 		if(pull == null){
+			pull = new GhprbPullRequest(repo.getPullRequest(id), ml, this);
+			if (pull != null){
+				pulls.put(id, pull);
+			}
+		}
+		if(pull == null){
 			if(logger.isLoggable(Level.FINER)){
 				logger.log(Level.FINER, "Pull request #{0} desn't exist", id);
 			}


### PR DESCRIPTION
When an issue comment hook is invoked but the pull request is not yet known it should at least try to fetch it. The same checking is already done in some other places:
- https://github.com/dirk-thomas/ghprb/blob/b10530426f3061da2f9f4927369aaeda12344130/src/main/java/org/jenkinsci/plugins/ghprb/GhprbRepository.java#L111
- https://github.com/dirk-thomas/ghprb/blob/b10530426f3061da2f9f4927369aaeda12344130/src/main/java/org/jenkinsci/plugins/ghprb/GhprbRepository.java#L245

This can e.g. happen if you restarted Jenkins or configure the jobs to use the plugin _after_ the pull request has been created. So the plugin never got notified about the PR and ignores the incoming comment hook.
