### PR TITLE
Removed unneeded success/failure message on non "build finished" comments

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbRepository.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbRepository.java
@@ -128,7 +128,7 @@ public class GhprbRepository {
                 logger.log(Level.INFO, "Could not update commit status of the Pull Request on GitHub. Trying to send comment.", ex);
                 if (state == GHCommitState.SUCCESS) {
                     message = message + " " + GhprbTrigger.getDscp().getMsgSuccess();
-                } else {
+                } else if (state == GHCommitState.FAILURE) {
                     message = message + " " + GhprbTrigger.getDscp().getMsgFailure();
                 }
                 addComment(id, message);


### PR DESCRIPTION
Current functionality produces:
BUILDBOT  commented 24 minutes ago 
Merged build triggered. Test PASSed.
BUILDBOT  commented 23 minutes ago 
Merged build started. Test PASSed.
BUILDBOT  commented 22 minutes ago 
Merged build finished. Test PASSed.

Proposed change functionality:
Current functionality produces:
BUILDBOT  commented 24 minutes ago 
Merged build triggered.
BUILDBOT  commented 23 minutes ago 
Merged build started.
BUILDBOT  commented 22 minutes ago 
Merged build finished. Test PASSed.

Success/failure messages shouldn't be coupled with build triggered and started messages.
