### PR TITLE
Set the the value of GIT_BRANCH when kicking off builds

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
@@ -137,6 +137,7 @@ public class GhprbTrigger extends Trigger<AbstractProject<?, ?>> {
         values.add(pullIdPv);
         values.add(new StringParameterValue("ghprbTargetBranch", String.valueOf(cause.getTargetBranch())));
         values.add(new StringParameterValue("ghprbSourceBranch", String.valueOf(cause.getSourceBranch())));
+        values.add(new StringParameterValue("GIT_BRANCH", String.valueOf(cause.getSourceBranch())));
         // it's possible the GHUser doesn't have an associated email address
         values.add(new StringParameterValue("ghprbPullAuthorEmail", cause.getAuthorEmail() != null ? cause.getAuthorEmail() : ""));
         values.add(new StringParameterValue("ghprbPullDescription", String.valueOf(cause.getShortDescription())));


### PR DESCRIPTION
Allows users to refer to the original branch name when rewriting build descriptors by using ${GIT_BRANCH}
