### PR TITLE
Support regular expressions in matching branch names with the whitelist

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbBranch.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbBranch.java
@@ -16,8 +16,8 @@ public class GhprbBranch extends AbstractDescribableImpl<GhprbBranch> {
         return branch;
     }
     
-    public boolean equals(String s){
-            return branch.equals(s.trim());
+    public boolean matches(String s){
+        return s.matches(branch);
     }
 
     @DataBoundConstructor

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbPullRequest.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbPullRequest.java
@@ -127,12 +127,12 @@ public class GhprbPullRequest {
 
     public boolean isWhiteListedTargetBranch() {
         List<GhprbBranch> branches = helper.getWhiteListTargetBranches();
-        if (branches.isEmpty() || (branches.size() == 1 && branches.get(0).equals(""))) {
+        if (branches.isEmpty() || (branches.size() == 1 && branches.get(0).getBranch().equals(""))) {
             // no branches in white list means we should test all
             return true;
         }
         for (GhprbBranch b : branches) {
-            if (b.equals(target)) {
+            if (b.matches(target)) {
                 // the target branch is in the whitelist!
                 return true;
             }

--- a/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/help-whiteListTargetBranches.html
+++ b/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/help-whiteListTargetBranches.html
@@ -1,3 +1,4 @@
 <div>
-  Adding branches to this whitelist allows you to selectively test pull requests destined for these branches only.
+  Adding branches to this whitelist allows you to selectively test pull requests destined for these branches only.<br/>
+  Supports regular expressions (e.g. 'master', 'feature-.*').
 </div>


### PR DESCRIPTION
This small change allowed me to create separate jenkins jobs for different branch types (feature branches, hotfix branches, develop, etc.). The benefits are that these jobs can be run in parallel or have different settings.
