### PR TITLE
[FIX]: URLs should be compared case-insensitively

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbRootAction.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbRootAction.java
@@ -105,7 +105,7 @@ public class GhprbRootAction implements UnprotectedRootAction {
                     continue;
                 }
                 GhprbRepository r = trigger.getRepository();
-                if (repo.equals(r.getName())) {
+                if (repo.equalsIgnoreCase(r.getName())) {
                     ret.add(r);
                 }
             }


### PR DESCRIPTION
After spending a few hours figuring out how Jenkins works, I finally drilled down my problem to this. The list of github repos that ghprb loops through in `doIndex` method are zero, and I am suspecting it's because our repo url it aptly/unaptly named "iOS", while we are unaptly/aptly using "ios" in the configuration.
