### PR TITLE
Ignore case when comparing repo names in pull request hook

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbRootAction.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbRootAction.java
@@ -127,6 +127,12 @@ public class GhprbRootAction implements UnprotectedRootAction {
         } finally {
             SecurityContextHolder.getContext().setAuthentication(old);
         }
+
+        if (repos.size() == 0) {
+            logger.log(Level.WARNING, "No repos with plugin trigger found for GitHub repo named {0}", 
+                new Object[] { repo.getFullName() });
+        }
+
         return ret;
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbRootAction.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbRootAction.java
@@ -120,7 +120,7 @@ public class GhprbRootAction implements UnprotectedRootAction {
                     continue;
                 }
                 GhprbRepository r = trigger.getRepository();
-                if (repo.equals(r.getName())) {
+                if (repo.equalsIgnoreCase(r.getName())) {
                     ret.add(r);
                 }
             }

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbRootAction.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbRootAction.java
@@ -128,9 +128,8 @@ public class GhprbRootAction implements UnprotectedRootAction {
             SecurityContextHolder.getContext().setAuthentication(old);
         }
 
-        if (repos.size() == 0) {
-            logger.log(Level.WARNING, "No repos with plugin trigger found for GitHub repo named {0}", 
-                new Object[] { repo.getFullName() });
+        if (ret.size() == 0) {
+            logger.log(Level.WARNING, "No repos with plugin trigger found for GitHub repo named {0}", repo);
         }
 
         return ret;


### PR DESCRIPTION
I've been driving myself totally spare trying to figure out why my pull requests weren't triggering a build via the hook (but were working fine with the cron), and it turns out that GitHub was providing the repo name as "something/Something-Else" but I'd put in the repo URL as "something/something-else". I was seeing "Got payload event: pull_request" in the logs, but then literally nothing afterwards.

This fixes the issue by ignoring case and adds some logging for future poor souls. In the meantime, the temporary workaround is to ensure the casing on your url configuration is correct.
 
Hope this helps someone!