### PR TITLE
Allow skip setting the commit status

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbPullRequest.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbPullRequest.java
@@ -44,7 +44,7 @@ public class GhprbPullRequest {
     private String source;
     private String authorEmail;
     private URL url;
-    
+
     private GHUser triggerSender;
     private GitUser commitAuthor;
 
@@ -55,7 +55,7 @@ public class GhprbPullRequest {
     private transient Ghprb helper;
     private transient GhprbRepository repo;
 
-	private String commentBody;
+    private String commentBody;
 
     GhprbPullRequest(GHPullRequest pr, Ghprb helper, GhprbRepository repo) {
         id = pr.getNumber();
@@ -91,38 +91,38 @@ public class GhprbPullRequest {
             reponame = repo.getName(); // If this instance was created before v1.8, it can be null.
         }
     }
-    
+
     /**
-     * Returns skip build phrases from Jenkins global configuration 
+     * Returns skip build phrases from Jenkins global configuration
      * @return
      */
     public Set<String> getSkipBuildPhrases() {
-		return new HashSet<String>(Arrays.asList(GhprbTrigger.getDscp().getSkipBuildPhrase().split("[\\r\\n]+")));
-	}
-	
+        return new HashSet<String>(Arrays.asList(GhprbTrigger.getDscp().getSkipBuildPhrase().split("[\\r\\n]+")));
+    }
+
     /**
      * Checks for skip build phrase in pull request comment. If present it updates shouldRun as false.
      * @param issue
      */
-	private void checkSkipBuild(GHIssue issue) {
-		// check for skip build phrase.
-		String pullRequestBody = issue.getBody();
-		if(StringUtils.isNotBlank(pullRequestBody)) {
-			pullRequestBody = pullRequestBody.trim();
-			Set<String> skipBuildPhrases = getSkipBuildPhrases();
-			skipBuildPhrases.remove("");
-			
-			for (String skipBuildPhrase : skipBuildPhrases) {
-				skipBuildPhrase = skipBuildPhrase.trim();
-				Pattern skipBuildPhrasePattern = Pattern.compile(skipBuildPhrase, Pattern.CASE_INSENSITIVE);
-				if(skipBuildPhrasePattern.matcher(pullRequestBody).matches()) {
-					logger.log(Level.INFO, "Pull request commented with {0} skipBuildPhrase. Hence skipping the build.", skipBuildPhrase);
-					shouldRun = false;
-					break;
-				}
-			}
-		}
-	}
+    private void checkSkipBuild(GHIssue issue) {
+        // check for skip build phrase.
+        String pullRequestBody = issue.getBody();
+        if(StringUtils.isNotBlank(pullRequestBody)) {
+            pullRequestBody = pullRequestBody.trim();
+            Set<String> skipBuildPhrases = getSkipBuildPhrases();
+            skipBuildPhrases.remove("");
+
+            for (String skipBuildPhrase : skipBuildPhrases) {
+                skipBuildPhrase = skipBuildPhrase.trim();
+                Pattern skipBuildPhrasePattern = Pattern.compile(skipBuildPhrase, Pattern.CASE_INSENSITIVE);
+                if(skipBuildPhrasePattern.matcher(pullRequestBody).matches()) {
+                    logger.log(Level.INFO, "Pull request commented with {0} skipBuildPhrase. Hence skipping the build.", skipBuildPhrase);
+                    shouldRun = false;
+                    break;
+                }
+            }
+        }
+    }
 
     /**
      * Checks this Pull Request representation against a GitHub version of the Pull Request, and triggers
@@ -217,16 +217,16 @@ public class GhprbPullRequest {
                 logger.log(Level.FINEST, "PR is not null, checking if mergable");
                 checkMergeable(pr);
                 try {
-	                for (GHPullRequestCommitDetail commitDetails : pr.listCommits()) {
-	    	    		if (commitDetails.getSha().equals(getHead())) {
-	    	    			commitAuthor = commitDetails.getCommit().getCommitter();
-	    	    			break;
-	    	    		}
-	    	    	}
+                    for (GHPullRequestCommitDetail commitDetails : pr.listCommits()) {
+                        if (commitDetails.getSha().equals(getHead())) {
+                            commitAuthor = commitDetails.getCommit().getCommitter();
+                            break;
+                        }
+                    }
                 } catch (Exception ex) {
-                	logger.log(Level.INFO, "Unable to get PR commits: ", ex);
+                    logger.log(Level.INFO, "Unable to get PR commits: ", ex);
                 }
-                
+
             }
 
             logger.log(Level.FINEST, "Running build...");
@@ -237,10 +237,12 @@ public class GhprbPullRequest {
         }
     }
 
-	private void build() {
+    private void build() {
         String message = helper.getBuilds().build(this, triggerSender, commentBody);
-        String context = helper.getTrigger().getCommitStatusContext();
-        repo.createCommitStatus(head, GHCommitState.PENDING, null, message,id,context);
+        if ( !helper.getTrigger().getSkipCommitStatus() ) {
+            String context = helper.getTrigger().getCommitStatusContext();
+            repo.createCommitStatus(head, GHCommitState.PENDING, null, message,id,context);
+        }
         logger.log(Level.INFO, message);
     }
 
@@ -303,10 +305,10 @@ public class GhprbPullRequest {
                 triggered = true;
             }
         }
-        
+
         if (shouldRun) {
-        	triggerSender = sender;
-        	commentBody = body;
+            triggerSender = sender;
+            commentBody = body;
         }
     }
 
@@ -410,11 +412,11 @@ public class GhprbPullRequest {
         return url;
     }
 
-	public GitUser getCommitAuthor() {
-		return commitAuthor;
-	}
-	
-	public GHPullRequest getPullRequest() {
-		return pr;
-	}
+    public GitUser getCommitAuthor() {
+        return commitAuthor;
+    }
+
+    public GHPullRequest getPullRequest() {
+        return pr;
+    }
 }

--- a/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/config.jelly
@@ -12,39 +12,42 @@
     <f:entry title="${%Failure message}" field="msgFailure">
       <f:textarea default="${descriptor.msgFailure}"/>
     </f:entry>
-	<f:entry title="${%Trigger phrase}" field="triggerPhrase">
-	  <f:textbox />
-	</f:entry>
-	<f:entry title="Only use trigger phrase for build triggering" field="onlyTriggerPhrase">
-	  <f:checkbox />
-	</f:entry>
-	<f:entry title="${%Close failed pull request automatically?}" field="autoCloseFailedPullRequests">
-	  <f:checkbox default="${descriptor.autoCloseFailedPullRequests}"/>
-	</f:entry>
-    <f:entry title="${%Skip build phrase}" field="skipBuildPhrase">
-  	  <f:textarea default="${descriptor.skipBuildPhrase}"/>
+    <f:entry title="${%Trigger phrase}" field="triggerPhrase">
+      <f:textbox />
     </f:entry>
-	<f:entry title="${%Display build errors on downstream builds?}" field="displayBuildErrorsOnDownstreamBuilds">
-	  <f:checkbox default="${descriptor.displayBuildErrorsOnDownstreamBuilds}"/>
-	</f:entry>
-	<f:entry title="${%Commit Status Context}" field="commitStatusContext">
-		<f:textbox />
-	</f:entry>
-	<f:entry title="${%Crontab line}" field="cron" help="/descriptor/hudson.triggers.TimerTrigger/help/spec">
-	  <f:textbox default="${descriptor.cron}" checkUrl="'descriptorByName/hudson.triggers.TimerTrigger/checkSpec?value=' + encodeURIComponent(this.value)"/>
-	</f:entry>
-	<f:entry title="${%White list}" field="whitelist">
-	  <f:textarea />
-	</f:entry>
-	<f:entry title="${%Comment file path}" field="commentFilePath">
-	  <f:textbox />
-	</f:entry>
-	<f:entry title="${%List of organisations. Their members will be whitelisted.}" field="orgslist">
-	  <f:textarea />
-	</f:entry>
-	<f:entry title="Allow members of whitelisted organisations as admins" field="allowMembersOfWhitelistedOrgsAsAdmin">
-	  <f:checkbox />
-	</f:entry>
+    <f:entry title="Only use trigger phrase for build triggering" field="onlyTriggerPhrase">
+      <f:checkbox />
+    </f:entry>
+    <f:entry title="${%Close failed pull request automatically?}" field="autoCloseFailedPullRequests">
+      <f:checkbox default="${descriptor.autoCloseFailedPullRequests}"/>
+    </f:entry>
+    <f:entry title="${%Skip build phrase}" field="skipBuildPhrase">
+      <f:textarea default="${descriptor.skipBuildPhrase}"/>
+    </f:entry>
+    <f:entry title="${%Display build errors on downstream builds?}" field="displayBuildErrorsOnDownstreamBuilds">
+      <f:checkbox default="${descriptor.displayBuildErrorsOnDownstreamBuilds}"/>
+    </f:entry>
+    <f:entry title="${%Skip setting the commit status?}" field="skipCommitStatus">
+      <f:checkbox default="${descriptor.skipCommitStatus}"/>
+    </f:entry>
+    <f:entry title="${%Commit Status Context}" field="commitStatusContext">
+        <f:textbox />
+    </f:entry>
+    <f:entry title="${%Crontab line}" field="cron" help="/descriptor/hudson.triggers.TimerTrigger/help/spec">
+      <f:textbox default="${descriptor.cron}" checkUrl="'descriptorByName/hudson.triggers.TimerTrigger/checkSpec?value=' + encodeURIComponent(this.value)"/>
+    </f:entry>
+    <f:entry title="${%White list}" field="whitelist">
+      <f:textarea />
+    </f:entry>
+    <f:entry title="${%Comment file path}" field="commentFilePath">
+      <f:textbox />
+    </f:entry>
+    <f:entry title="${%List of organisations. Their members will be whitelisted.}" field="orgslist">
+      <f:textarea />
+    </f:entry>
+    <f:entry title="Allow members of whitelisted organisations as admins" field="allowMembersOfWhitelistedOrgsAsAdmin">
+      <f:checkbox />
+    </f:entry>
     <f:entry title="Build every pull request automatically without asking (Dangerous!)." field="permitAll">
       <f:checkbox />
     </f:entry>

--- a/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/global.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/global.jelly
@@ -34,7 +34,10 @@
       </f:entry>
       <f:entry title="${%Display build errors on downstream builds?}" field="displayBuildErrorsOnDownstreamBuilds">
         <f:checkbox />
-	  </f:entry>
+      </f:entry>
+      <f:entry title="${%Skip setting the commit status?}" field="skipCommitStatus">
+        <f:checkbox />
+      </f:entry>
       <f:entry title="${%Commit Status Context}" field="commitStatusContext">
         <f:textbox />
       </f:entry>
@@ -51,7 +54,7 @@
         <f:textbox default=".*test\W+this\W+please.*"/>
       </f:entry>
       <f:entry title="${%Skip build phrase}" field="skipBuildPhrase">
-      	<f:textbox default=".*\[skip\W+ci\].*"/>
+        <f:textbox default=".*\[skip\W+ci\].*"/>
       </f:entry>
       <f:entry title="${%Crontab line}" field="cron" help="/descriptor/hudson.triggers.TimerTrigger/help/spec">
         <f:textbox default="H/5 * * * *" checkUrl="'descriptorByName/hudson.triggers.TimerTrigger/checkSpec?value=' + encodeURIComponent(this.value)"/>

--- a/src/test/java/org/jenkinsci/plugins/ghprb/GhprbIT.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GhprbIT.java
@@ -40,7 +40,7 @@ public class GhprbIT extends GhprbITBaseTestCase {
         // GIVEN
         FreeStyleProject project = jenkinsRule.createFreeStyleProject("PRJ");
         GhprbTrigger trigger = new GhprbTrigger(
-                "user", "user", "", "*/1 * * * *", "retest this please", false, false, false, false, false, null, null, false, null, null, null
+                "user", "user", "", "*/1 * * * *", "retest this please", false, false, false, false, false, null, null, false, null, null, null, false
         );
         given(commitPointer.getSha()).willReturn("sha");
         JSONObject jsonObject = GhprbTestUtil.provideConfiguration();
@@ -74,7 +74,7 @@ public class GhprbIT extends GhprbITBaseTestCase {
         // GIVEN
         FreeStyleProject project = jenkinsRule.createFreeStyleProject("PRJ");
         GhprbTrigger trigger = new GhprbTrigger(
-                "user", "user", "", "*/1 * * * *", "retest this please", false, false, false, false, false, null, null, false, null, null, null
+                "user", "user", "", "*/1 * * * *", "retest this please", false, false, false, false, false, null, null, false, null, null, null, false
         );
         given(commitPointer.getSha()).willReturn("sha").willReturn("sha").willReturn("newOne").willReturn("newOne");
         given(ghPullRequest.getComments()).willReturn(Lists.<GHIssueComment>newArrayList());
@@ -102,7 +102,7 @@ public class GhprbIT extends GhprbITBaseTestCase {
         // GIVEN
         FreeStyleProject project = jenkinsRule.createFreeStyleProject("PRJ");
         GhprbTrigger trigger = new GhprbTrigger(
-                "user", "user", "", "*/1 * * * *", "retest this please", false, false, false, false, false, null, null, false, null, null, null
+                "user", "user", "", "*/1 * * * *", "retest this please", false, false, false, false, false, null, null, false, null, null, null, false
         );
 
         given(commitPointer.getSha()).willReturn("sha");

--- a/src/test/java/org/jenkinsci/plugins/ghprb/GhprbPullRequestMergeTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GhprbPullRequestMergeTest.java
@@ -92,7 +92,7 @@ public class GhprbPullRequestMergeTest {
 	
 	@Before 
 	public void beforeTest() throws Exception {
-		GhprbTrigger trigger = spy(new GhprbTrigger(adminList, "user", "", "*/1 * * * *", triggerPhrase, false, false, false, false, false, null, null, false, null, null, null));
+		GhprbTrigger trigger = spy(new GhprbTrigger(adminList, "user", "", "*/1 * * * *", triggerPhrase, false, false, false, false, false, null, null, false, null, null, null, false));
 
 		ConcurrentMap<Integer, GhprbPullRequest> pulls = new ConcurrentHashMap<Integer, GhprbPullRequest>(1);
 		pulls.put(pullId, pullRequest);

--- a/src/test/java/org/jenkinsci/plugins/ghprb/GhprbTestUtil.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GhprbTestUtil.java
@@ -105,6 +105,8 @@ public class GhprbTestUtil {
 		jsonObject.put("msgSuccess", "Success");
 		jsonObject.put("msgFailure", "Failure");
 		jsonObject.put("commitStatusContext", "Status Context");
+		jsonObject.put("skipCommitStatus", "false");
+
 
 		return jsonObject;
 	}

--- a/src/test/java/org/jenkinsci/plugins/ghprb/manager/impl/GhprbDefaultBuildManagerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/manager/impl/GhprbDefaultBuildManagerTest.java
@@ -66,7 +66,7 @@ public class GhprbDefaultBuildManagerTest extends GhprbITBaseTestCase {
 
 		GhprbTrigger trigger = new GhprbTrigger("user", "user", "",
 			"*/1 * * * *", "retest this please", false, false, false, false,
-			false, null, null, false, null, null, null);
+			false, null, null, false, null, null, null, false);
 
 		given(commitPointer.getSha()).willReturn("sha");
 

--- a/src/test/java/org/jenkinsci/plugins/ghprb/manager/impl/downstreambuilds/BuildFlowBuildManagerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/manager/impl/downstreambuilds/BuildFlowBuildManagerTest.java
@@ -109,7 +109,7 @@ public class BuildFlowBuildManagerTest extends GhprbITBaseTestCase {
 
 		GhprbTrigger trigger = new GhprbTrigger("user", "user", "",
 			"*/1 * * * *", "retest this please", false, false, false, false,
-			false, null, null, false, null, null, null);
+			false, null, null, false, null, null, null, false);
 
 		given(commitPointer.getSha()).willReturn("sha");
 		JSONObject jsonObject = GhprbTestUtil.provideConfiguration();


### PR DESCRIPTION
I've added this setting in because our Jenkins setup involves a testing, a staging and production Jenkins instances. We only want the production instance to set the commit statuses, though, on the other instances we still want to handle the pull requests.