### PR TITLE
make comments case insensitive

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbPullRequest.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbPullRequest.java
@@ -295,7 +295,7 @@ public class GhprbPullRequest {
 
     private void checkComment(GHIssueComment comment) throws IOException {
         GHUser sender = comment.getUser();
-        String body = comment.getBody();
+        String body = comment.getBody().toLowerCase();
 
         // Disabled until more advanced configs get set up
         // ignore comments from bot user, this fixes an issue where the bot would auto-whitelist


### PR DESCRIPTION
sometime we write comments with uppercase letter, especially if mobile devices with auto-correction involved.
Make comment body lowercase to react to such comments as well.