### PR TITLE
Fixes #2723: Do not fail build if merge is only on trigger phrase & trigger phrase is not specified

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <artifactId>ghprb</artifactId>
     <name>GitHub Pull Request Builder</name>
-    <version>1.24.4</version>
+    <version>1.25-SNAPSHOT</version>
     <packaging>hpi</packaging>
 
     <url>https://wiki.jenkins-ci.org/display/JENKINS/GitHub+pull+request+builder+plugin</url>
@@ -31,7 +31,7 @@
         <connection>scm:git:ssh://github.com/jenkinsci/ghprb-plugin.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/jenkinsci/ghprb-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/ghprb-plugin</url>
-        <tag>ghprb-1.24.4</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <issueManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <artifactId>ghprb</artifactId>
     <name>GitHub Pull Request Builder</name>
-    <version>1.25-SNAPSHOT</version>
+    <version>1.24.4</version>
     <packaging>hpi</packaging>
 
     <url>https://wiki.jenkins-ci.org/display/JENKINS/GitHub+pull+request+builder+plugin</url>
@@ -31,7 +31,7 @@
         <connection>scm:git:ssh://github.com/jenkinsci/ghprb-plugin.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/jenkinsci/ghprb-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/ghprb-plugin</url>
-        <tag>HEAD</tag>
+        <tag>ghprb-1.24.4</tag>
     </scm>
 
     <issueManagement>

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbPullRequestMerge.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbPullRequestMerge.java
@@ -1,33 +1,27 @@
 package org.jenkinsci.plugins.ghprb;
 
-import java.io.IOException;
-import java.io.PrintStream;
-import java.util.concurrent.ConcurrentMap;
-
-import org.kohsuke.github.GHBranch;
-import org.kohsuke.github.GHPullRequestCommitDetail.Commit;
-import org.kohsuke.github.GHPullRequest;
-import org.kohsuke.github.GHPullRequestCommitDetail;
-import org.kohsuke.github.GHUser;
-import org.kohsuke.stapler.AncestorInPath;
-import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.QueryParameter;
-
 import com.google.common.annotations.VisibleForTesting;
-
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.Launcher;
-import hudson.model.BuildListener;
-import hudson.model.Cause;
-import hudson.model.Result;
-import hudson.model.AbstractBuild;
-import hudson.model.AbstractProject;
+import hudson.model.*;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.BuildStepMonitor;
 import hudson.tasks.Publisher;
 import hudson.tasks.Recorder;
 import hudson.util.FormValidation;
+import org.kohsuke.github.GHBranch;
+import org.kohsuke.github.GHPullRequest;
+import org.kohsuke.github.GHPullRequestCommitDetail;
+import org.kohsuke.github.GHPullRequestCommitDetail.Commit;
+import org.kohsuke.github.GHUser;
+import org.kohsuke.stapler.AncestorInPath;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.QueryParameter;
+
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.concurrent.ConcurrentMap;
 
 public class GhprbPullRequestMerge extends Recorder {
 
@@ -158,11 +152,8 @@ public class GhprbPullRequestMerge extends Recorder {
             // deleteBranch(); //TODO: Update so it also deletes the branch being pulled from. probably make it an option.
         }
 
-        if (merge) {
-            listener.finished(Result.SUCCESS);
-        } else {
-            listener.finished(Result.FAILURE);
-        }
+        listener.finished(Result.SUCCESS);
+
         return merge;
     }
 

--- a/src/test/java/org/jenkinsci/plugins/ghprb/GhprbPullRequestMergeTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GhprbPullRequestMergeTest.java
@@ -1,21 +1,7 @@
 package org.jenkinsci.plugins.ghprb;
 
-import java.io.IOException;
-import java.io.PrintStream;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
-import java.lang.reflect.Field;
-
-import hudson.model.AbstractBuild;
-import hudson.model.FreeStyleBuild;
-import hudson.model.ItemGroup;
-import hudson.model.StreamBuildListener;
-import hudson.model.FreeStyleProject;
-import hudson.model.Run;
-import hudson.model.Result;
-
+import com.coravy.hudson.plugins.github.GithubProjectProperty;
+import hudson.model.*;
 import org.jenkinsci.plugins.ghprb.GhprbTrigger.DescriptorImpl;
 import org.junit.After;
 import org.junit.Before;
@@ -23,27 +9,26 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.jvnet.hudson.test.JenkinsRule;
-import org.kohsuke.github.GHPullRequest;
-import org.kohsuke.github.GHPullRequestCommitDetail;
+import org.kohsuke.github.*;
 import org.kohsuke.github.GHPullRequestCommitDetail.Commit;
-import org.kohsuke.github.GHUser;
-import org.kohsuke.github.GitUser;
-import org.kohsuke.github.PagedIterable;
-import org.kohsuke.github.PagedIterator;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
 
-import com.coravy.hudson.plugins.github.GithubProjectProperty;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 import static org.fest.assertions.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.anyInt;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.doNothing;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
 public class GhprbPullRequestMergeTest {
@@ -98,7 +83,7 @@ public class GhprbPullRequestMergeTest {
         triggerValues = new HashMap<String, Object>(10);
         triggerValues.put("adminlist", adminList);
         triggerValues.put("triggerPhrase", triggerPhrase);
-        
+
         GhprbTrigger trigger = spy(GhprbTestUtil.getTrigger(triggerValues));
 
         ConcurrentMap<Integer, GhprbPullRequest> pulls = new ConcurrentHashMap<Integer, GhprbPullRequest>(1);
@@ -291,13 +276,13 @@ public class GhprbPullRequestMergeTest {
         assertThat(merger.perform(build, null, listener)).isEqualTo(false);
 
         setupConditions(nonAdminLogin, nonCommitterName, nonTriggerPhrase);
-        assertThat(merger.perform(build, null, listener)).isEqualTo(false);
+        assertThat(merger.perform(build, null, listener)).isEqualTo(true);
 
         setupConditions(adminLogin, committerName, nonTriggerPhrase);
-        assertThat(merger.perform(build, null, listener)).isEqualTo(false);
+        assertThat(merger.perform(build, null, listener)).isEqualTo(true);
 
         setupConditions(nonAdminLogin, committerName, nonTriggerPhrase);
-        assertThat(merger.perform(build, null, listener)).isEqualTo(false);
+        assertThat(merger.perform(build, null, listener)).isEqualTo(true);
 
         setupConditions(adminLogin, nonCommitterName, triggerPhrase);
         assertThat(merger.perform(build, null, listener)).isEqualTo(true);


### PR DESCRIPTION
This means that the PR build will run & will show success on the github PR page showing the build was successful but not even try to merge. A user should then come along & run the build again by adding a comment with the merge trigger phrase to run the build & merge.