### PR TITLE
Statistics on completion

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbBuilds.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbBuilds.java
@@ -139,7 +139,7 @@ public class GhprbBuilds {
         } else {
             replyMessage.append("Build finished. ");
         }
-        replyMessage.append(buildManager.getTestResults());
+        replyMessage.append(buildManager.getOneLineTestResults());
         repo.createCommitStatus(build, state, replyMessage.toString(), c.getPullID(), trigger.getCommitStatusContext(), listener.getLogger());
 
         buildResultMessage(build, listener, state, c);

--- a/src/main/java/org/jenkinsci/plugins/ghprb/manager/GhprbBuildManager.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/manager/GhprbBuildManager.java
@@ -22,6 +22,13 @@ public interface GhprbBuildManager {
     Iterator<?> downstreamProjects();
 
     /**
+     * Print tests result of a build in one line.
+     *
+     * @return the tests result
+     */
+    String getOneLineTestResults();
+
+    /**
      * Print tests result of a build
      *
      * @return the tests result

--- a/src/main/java/org/jenkinsci/plugins/ghprb/manager/impl/GhprbBaseBuildManager.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/manager/impl/GhprbBaseBuildManager.java
@@ -13,10 +13,12 @@ import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
 import hudson.model.Result;
 import hudson.tasks.junit.TestResult;
+import hudson.tasks.junit.TestResultAction;
 import hudson.tasks.junit.CaseResult;
 import hudson.tasks.test.AggregatedTestResultAction;
 import hudson.tasks.test.AggregatedTestResultAction.ChildReport;
 
+import org.jenkinsci.plugins.ghprb.GhprbTrigger;
 import org.jenkinsci.plugins.ghprb.manager.configuration.JobConfiguration;
 import org.jenkinsci.plugins.ghprb.manager.GhprbBuildManager;
 
@@ -167,6 +169,16 @@ public abstract class GhprbBaseBuildManager implements GhprbBuildManager {
     }
 
     protected static final Logger LOGGER = Logger.getLogger(GhprbBaseBuildManager.class.getName());
+
+    public String getOneLineTestResults() {
+
+        TestResultAction testResultAction = build.getAction(TestResultAction.class);
+
+        if (testResultAction == null) {
+            return "No test results found.";
+        }
+        return String.format("%d tests run, %d skipped, %d failed.", testResultAction.getTotalCount(), testResultAction.getSkipCount(), testResultAction.getFailCount());
+    }
 
     protected AbstractBuild<?, ?> build;
 


### PR DESCRIPTION
Appends detailed test runner details from Jenkins to the information appended to the GH status message - for example, `Merged build finished. 44165 tests run, 1024 skipped, 5 failed.`