### PR TITLE
Add trigger comment to environment variables

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
@@ -223,6 +223,7 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
 
         setCommitAuthor(cause, values);
 
+        values.add(new StringParameterValue("ghprbTriggerComment", cause.getCommentBody()));
         values.add(new StringParameterValue("ghprbTriggerAuthor", triggerAuthor));
         values.add(new StringParameterValue("ghprbTriggerAuthorEmail", triggerAuthorEmail));
         final StringParameterValue pullIdPv = new StringParameterValue("ghprbPullId", String.valueOf(cause.getPullID()));


### PR DESCRIPTION
As discussed in issues https://github.com/janinko/ghprb/issues/229 and https://github.com/janinko/ghprb/issues/223, this change will provide the jenkins job with the pull request comment that was used to trigger the build. An example of how this could be used would be to provide the name of a test scheme in a GitHub comment - _retest scheme1 please_ - for use by a build script.