### PR TITLE
change 'Build started' message to match the other status messages

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/extensions/status/GhprbSimpleStatus.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/extensions/status/GhprbSimpleStatus.java
@@ -120,7 +120,7 @@ public class GhprbSimpleStatus extends GhprbExtension implements GhprbCommitStat
         GhprbCause c = Ghprb.getCause(build);
         StringBuilder sb = new StringBuilder();
         if (StringUtils.isEmpty(startedStatus)) {
-            sb.append("Build Started");
+            sb.append("Build started.");
             sb.append(c.isMerged() ? " sha1 is merged." : " sha1 is original commit.");
         } else {
             sb.append(Ghprb.replaceMacros(build, listener, startedStatus));


### PR DESCRIPTION
This is a super super minor/low priority PR for changing the appearance of the build status message when it first starts so it matches the other messages:

`Build triggered. sha1 is merged.`
`Build started. sha1 is merged.`