### PR TITLE
Skip builds for unmerged pullrequests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <artifactId>ghprb</artifactId>
     <name>GitHub Pull Request Builder</name>
-    <version>1.29</version>
+    <version>1.30-SNAPSHOT</version>
     <packaging>hpi</packaging>
 
     <url>https://wiki.jenkins-ci.org/display/JENKINS/GitHub+pull+request+builder+plugin</url>
@@ -31,7 +31,7 @@
         <connection>scm:git:ssh://github.com/jenkinsci/ghprb-plugin.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/jenkinsci/ghprb-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/ghprb-plugin</url>
-        <tag>ghprb-1.29</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <issueManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <artifactId>ghprb</artifactId>
     <name>GitHub Pull Request Builder</name>
-    <version>1.29-SNAPSHOT</version>
+    <version>1.29</version>
     <packaging>hpi</packaging>
 
     <url>https://wiki.jenkins-ci.org/display/JENKINS/GitHub+pull+request+builder+plugin</url>
@@ -31,7 +31,7 @@
         <connection>scm:git:ssh://github.com/jenkinsci/ghprb-plugin.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/jenkinsci/ghprb-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/ghprb-plugin</url>
-        <tag>HEAD</tag>
+        <tag>ghprb-1.29</tag>
     </scm>
 
     <issueManagement>

--- a/src/main/java/org/jenkinsci/plugins/ghprb/Ghprb.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/Ghprb.java
@@ -1,32 +1,33 @@
 package org.jenkinsci.plugins.ghprb;
 
-import com.cloudbees.plugins.credentials.CredentialsMatchers;
-import com.cloudbees.plugins.credentials.CredentialsProvider;
-import com.cloudbees.plugins.credentials.CredentialsScope;
-import com.cloudbees.plugins.credentials.CredentialsStore;
-import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
-import com.cloudbees.plugins.credentials.common.StandardCredentials;
-import com.cloudbees.plugins.credentials.domains.Domain;
-import com.cloudbees.plugins.credentials.domains.DomainSpecification;
-import com.cloudbees.plugins.credentials.domains.HostnamePortSpecification;
-import com.cloudbees.plugins.credentials.domains.HostnameSpecification;
-import com.cloudbees.plugins.credentials.domains.PathSpecification;
-import com.cloudbees.plugins.credentials.domains.SchemeSpecification;
-import com.cloudbees.plugins.credentials.domains.URIRequirementBuilder;
-import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
-import com.coravy.hudson.plugins.github.GithubProjectProperty;
-
 import hudson.Util;
-import hudson.model.AbstractBuild;
-import hudson.model.AbstractProject;
-import hudson.model.Cause;
 import hudson.model.Item;
 import hudson.model.Result;
 import hudson.model.Saveable;
 import hudson.model.TaskListener;
+import hudson.model.AbstractBuild;
+import hudson.model.AbstractProject;
+import hudson.model.Cause;
 import hudson.security.ACL;
 import hudson.util.DescribableList;
 import hudson.util.Secret;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentMap;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import jenkins.model.Jenkins;
 
 import org.apache.commons.collections.Predicate;
 import org.apache.commons.collections.PredicateUtils;
@@ -40,14 +41,21 @@ import org.kohsuke.github.GHCommitState;
 import org.kohsuke.github.GHIssue;
 import org.kohsuke.github.GHUser;
 
-import java.net.URI;
-import java.util.*;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
-import jenkins.model.Jenkins;
+import com.cloudbees.plugins.credentials.CredentialsMatchers;
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.CredentialsStore;
+import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
+import com.cloudbees.plugins.credentials.common.StandardCredentials;
+import com.cloudbees.plugins.credentials.domains.Domain;
+import com.cloudbees.plugins.credentials.domains.DomainSpecification;
+import com.cloudbees.plugins.credentials.domains.URIRequirementBuilder;
+import com.cloudbees.plugins.credentials.domains.HostnamePortSpecification;
+import com.cloudbees.plugins.credentials.domains.HostnameSpecification;
+import com.cloudbees.plugins.credentials.domains.PathSpecification;
+import com.cloudbees.plugins.credentials.domains.SchemeSpecification;
+import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
+import com.coravy.hudson.plugins.github.GithubProjectProperty;
 
 /**
  * @author janinko
@@ -215,6 +223,10 @@ public class Ghprb {
 
     public boolean isTriggerPhrase(String comment) {
         return triggerPhrase().matcher(comment).matches();
+    }
+
+    public boolean isSkipUnmergeablePullRequests() {
+    	return trigger.isSkipUnmergeablePullRequests();
     }
 
     public boolean ifOnlyTriggerPhrase() {

--- a/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/config.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/config.groovy
@@ -24,6 +24,9 @@ f.advanced() {
   f.entry(field: "skipBuildPhrase", title: _("Skip build phrase")) {
     f.textarea(default: descriptor.skipBuildPhrase) 
   }
+  f.entry(field: "skipUnmergeablePullRequests", title: _("Skip build, if pull request could not be merged?")) {
+	  f.checkbox(default: descriptor.skipUnmergeablePullRequests)
+	}
   f.entry(field: "displayBuildErrorsOnDownstreamBuilds", title: _("Display build errors on downstream builds?")) {
     f.checkbox(default: descriptor.displayBuildErrorsOnDownstreamBuilds) 
   }

--- a/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/global.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/global.groovy
@@ -40,6 +40,9 @@ f.section(title: descriptor.displayName) {
     f.entry(field: "skipBuildPhrase", title: _("Skip build phrase")) {
       f.textbox(default: ".*\\[skip\\W+ci\\].*") 
     }
+    f.entry(field: "skipUnmergeablePullRequests", title: _("Skip build, if pull request could not be merged?")) {
+	  f.checkbox()
+	}
     f.entry(field: "cron", title: _("Crontab line"), help: "/descriptor/hudson.triggers.TimerTrigger/help/spec") {
       f.textbox(default: "H/5 * * * *", checkUrl: "'descriptorByName/hudson.triggers.TimerTrigger/checkSpec?value=' + encodeURIComponent(this.value)") 
     }

--- a/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/help-skipUnmergeablePullRequests.html
+++ b/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/help-skipUnmergeablePullRequests.html
@@ -1,0 +1,4 @@
+<div>
+	When checked, <em>GitHub Pull Request Builder</em> will only trigger a build,
+	if the pull request is in a mergeable state.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/help-useComments.html
+++ b/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/help-useComments.html
@@ -1,5 +1,5 @@
 <div>
 	When checked, <em>GitHub Pull Request Builder</em> will try to add comment
 	with results if updating commit status fails. This can happen when user
-	doesn't have push rights for your repository.
+	doesn't have push rights for your repository.is in a mergeable state.
 </div>

--- a/src/test/java/org/jenkinsci/plugins/ghprb/GhprbRepositoryTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GhprbRepositoryTest.java
@@ -261,6 +261,7 @@ public class GhprbRepositoryTest {
         verify(helper, times(5)).isProjectDisabled();
         verify(helper, times(2)).checkSkipBuild(eq(ghPullRequest));
         verify(helper, times(3)).getTrigger();
+        verify(helper).isSkipUnmergeablePullRequests();
         verifyNoMoreInteractions(helper);
 
         verify(ghUser, times(2)).getEmail(); // Call to Github API
@@ -351,6 +352,7 @@ public class GhprbRepositoryTest {
         verify(helper).isTriggerPhrase(eq("comment body"));
         verify(helper, times(6)).isProjectDisabled();
         verify(helper, times(2)).checkSkipBuild(eq(ghPullRequest));
+        verify(helper).isSkipUnmergeablePullRequests();
         verifyNoMoreInteractions(helper);
 
         verify(ghUser, times(2)).getEmail(); // Call to Github API
@@ -441,6 +443,7 @@ public class GhprbRepositoryTest {
         verify(helper, times(6)).isProjectDisabled();
         verify(helper, times(2)).checkSkipBuild(eq(ghPullRequest));
         verify(helper, times(4)).getTrigger();
+        verify(helper, times(2)).isSkipUnmergeablePullRequests();
         verifyNoMoreInteractions(helper);
 
         verify(ghUser, times(3)).getEmail(); // Call to Github API

--- a/src/test/java/org/jenkinsci/plugins/ghprb/GhprbTestUtil.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GhprbTestUtil.java
@@ -40,7 +40,6 @@ import hudson.plugins.git.UserRemoteConfig;
 import net.sf.json.JSONObject;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.when;
 
 public class GhprbTestUtil {
 
@@ -305,6 +304,7 @@ public class GhprbTestUtil {
         jsonObject.put("unstableAs", "FAILURE");
         jsonObject.put("testMode", "true");
         jsonObject.put("autoCloseFailedPullRequests", "false");
+        jsonObject.put("skipUnmergeablePullRequests", "false");
         jsonObject.put("displayBuildErrorsOnDownstreamBuilds", "false");
         jsonObject.put("msgSuccess", "Success");
         jsonObject.put("msgFailure", "Failure");


### PR DESCRIPTION
Hi,

in our company, we would like to make sure, that builds for a new pull request are only triggered, if that PR is in a mergeable state. I thought, this feature might be interesting for others as well.
Can you imagine, to introduce this feature into your codebase?

Additionally ghprb could add a comment to the pull request, to inform the user about the fact, that Jenkins won't execute a build, until it is in a mergeable state. Else, a user might get confused, if he enters "test this please" and nothing happens.