### PR TITLE
Fix "No test results found" in Github build status

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/manager/impl/GhprbBaseBuildManager.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/manager/impl/GhprbBaseBuildManager.java
@@ -12,8 +12,8 @@ import jenkins.model.Jenkins;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
 import hudson.model.Result;
+import hudson.tasks.test.AbstractTestResultAction;
 import hudson.tasks.junit.TestResult;
-import hudson.tasks.junit.TestResultAction;
 import hudson.tasks.junit.CaseResult;
 import hudson.tasks.test.AggregatedTestResultAction;
 import hudson.tasks.test.AggregatedTestResultAction.ChildReport;
@@ -172,7 +172,7 @@ public abstract class GhprbBaseBuildManager implements GhprbBuildManager {
 
     public String getOneLineTestResults() {
 
-        TestResultAction testResultAction = build.getAction(TestResultAction.class);
+        AbstractTestResultAction testResultAction = build.getAction(AbstractTestResultAction.class);
 
         if (testResultAction == null) {
             return "No test results found.";


### PR DESCRIPTION
- fixes issue #315
- use AbstractTestResultAction instead of TestResultAction
- see https://github.com/jenkinsci/jenkins/commit/37c5bc2fd8616dbf4525c3a816e316015b4ff99e