### PR TITLE
if no tests are found return an empty string

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/manager/impl/GhprbBaseBuildManager.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/manager/impl/GhprbBaseBuildManager.java
@@ -43,7 +43,7 @@ public abstract class GhprbBaseBuildManager implements GhprbBuildManager {
 
     /**
      * Calculate the build URL of a build of default type. This will be overriden by specific build types.
-     * 
+     *
      * @return the build URL of a build of default type
      */
     public String calculateBuildUrl(String publishedURL) {
@@ -175,7 +175,7 @@ public abstract class GhprbBaseBuildManager implements GhprbBuildManager {
         AbstractTestResultAction testResultAction = build.getAction(AbstractTestResultAction.class);
 
         if (testResultAction == null) {
-            return "No test results found.";
+            return "";
         }
         return String.format("%d tests run, %d skipped, %d failed.", testResultAction.getTotalCount(), testResultAction.getSkipCount(), testResultAction.getFailCount());
     }


### PR DESCRIPTION
Because otherwise it will force users to have a junit file to be able
to report on tests run/failed/skipped. This is not always available and it is
entirely optional (vs. just handling a non-zero exit status as a failure).

Fixes Issue #315 