### PR TITLE
Handle "edited" pull-request hooks

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbRepository.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbRepository.java
@@ -373,7 +373,7 @@ public class GhprbRepository implements Saveable{
             pullRequests.remove(number);
         } else if (!trigger.isActive()) {
             logger.log(Level.FINE, "Not processing Pull request since the build is disabled");
-        } else if ("opened".equals(action) || "reopened".equals(action) || "synchronize".equals(action)) {
+        } else if ("edited".equals(action) || "opened".equals(action) || "reopened".equals(action) || "synchronize".equals(action)) {
             GhprbPullRequest pull = getPullRequest(ghpr, false, number);
             pull.check(ghpr);
         } else {


### PR DESCRIPTION
Since the description and title also make it into the builds as
variables, the edited hook should also be a valid trigger to trigger new
builds when these pieces of data change.

One use-case is validations on the description message to include a
proper change log.
