### PR TITLE
Add support for github labels ignore list

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ For more details, see https://wiki.jenkins-ci.org/display/JENKINS/GitHub+pull+re
   * The phrase for accepting a pull request for testing. (Java regexp)
   * The phrase for starting a new build. (Java regexp)  
   * The crontab line. This specify default setting for new jobs.  
+  * Github labels for which the build will not be triggered (for example, "in progress")  
 * Under Application Setup
   * There are global and job default extensions that can be configured for things like:
     * Commit status updates

--- a/src/main/java/org/jenkinsci/plugins/ghprb/Ghprb.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/Ghprb.java
@@ -135,6 +135,16 @@ public class Ghprb {
         }
         return null;
     }
+
+    public Set<String> getLabels() {
+        String labelsField = getTrigger().getLabelslist();
+        Set<String> labels = new HashSet<String>();
+        if (labelsField != null) {
+            String[] split = labelsField.split("\\s+");
+            Collections.addAll(labels, split);
+        }
+        return labels;
+    }
     
     private Pattern whitelistPhrasePattern() {
         return compilePattern(trigger.getDescriptor().getWhitelistPhrase());

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbPullRequest.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbPullRequest.java
@@ -174,7 +174,6 @@ public class GhprbPullRequest {
         try {
             for (GHLabel label : ghpr.getLabels()) {
                 if (labelsToSkip.contains(label.getName())) {
-                    logger.info("Found label in ignore list: " + label.getName());
                     return true;
                 }
             }

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbPullRequest.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbPullRequest.java
@@ -16,6 +16,7 @@ import org.kohsuke.github.GitUser;
 
 import java.io.IOException;
 import java.net.URL;
+import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 import java.util.Set;
@@ -166,17 +167,20 @@ public class GhprbPullRequest {
 
     private void checkLabels() {
         Set<String> labelsToSkip = helper.getLabels();
-        try {
-            for (GHLabel label : pr.getLabels()) {
-                if (labelsToSkip.contains(label.getName())) {
-                    logger.log(Level.INFO,
-                            "Found label {0} in ignore list, pull request will be ignored.",
-                            label.getName());
-                    shouldRun = false;
+        if (labelsToSkip != null && !labelsToSkip.isEmpty()) {
+            try {
+                for (GHLabel label : pr.getLabels()) {
+                    if (labelsToSkip.contains(label.getName())) {
+                        logger.log(Level.INFO,
+                                "Found label {0} in ignore list, pull request will be ignored.",
+                                label.getName());
+                        shouldRun = false;
+                    }
                 }
+
+            } catch(IOException e) {
+                logger.log(Level.SEVERE, "Failed to read labels", e);
             }
-        } catch (IOException e) {
-            logger.log(Level.SEVERE, "Failed to read labels", e);
         }
     }
 

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
@@ -83,6 +83,7 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
     private List<GhprbBranch> whiteListTargetBranches;
     private String gitHubAuthId;
     private String triggerPhrase;
+    private String labelslist;
     
 
     private transient Ghprb helper;
@@ -136,6 +137,7 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
             String commitStatusContext,
             String gitHubAuthId,
             String buildDescTemplate,
+            String labelslist,
             List<GhprbExtension> extensions
             ) throws ANTLRException {
         super(cron);
@@ -153,6 +155,7 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
         this.gitHubAuthId = gitHubAuthId;
         this.allowMembersOfWhitelistedOrgsAsAdmin = allowMembersOfWhitelistedOrgsAsAdmin;
         this.buildDescTemplate = buildDescTemplate;
+        this.labelslist = labelslist;
         setExtensions(extensions);
         configVersion = latestVersion;
     }
@@ -491,6 +494,10 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
         return triggerPhrase;
     }
 
+    public String getLabelslist() {
+        return labelslist;
+    }
+
     public Boolean getOnlyTriggerPhrase() {
         return onlyTriggerPhrase != null && onlyTriggerPhrase;
     }
@@ -642,7 +649,8 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
         private Boolean displayBuildErrorsOnDownstreamBuilds = false;
         
         private List<GhprbGitHubAuth> githubAuth;
-        
+        private String labelslist;
+
         public GhprbGitHubAuth getGitHubAuth(String gitHubAuthId) {
             
             if (gitHubAuthId == null) {
@@ -751,7 +759,8 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
             unstableAs = GHCommitState.valueOf(formData.getString("unstableAs"));
             autoCloseFailedPullRequests = formData.getBoolean("autoCloseFailedPullRequests");
             displayBuildErrorsOnDownstreamBuilds = formData.getBoolean("displayBuildErrorsOnDownstreamBuilds");
-            
+            labelslist = formData.getString("labelslist");
+
             githubAuth = req.bindJSONToList(GhprbGitHubAuth.class, formData.get("githubAuth"));
             
             extensions = new DescribableList<GhprbExtension, GhprbExtensionDescriptor>(Saveable.NOOP);
@@ -829,6 +838,9 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
             return useDetailedComments;
         }
 
+        public String getLabelslist() {
+            return labelslist;
+        }
 
         public Boolean getAutoCloseFailedPullRequests() {
             return autoCloseFailedPullRequests;
@@ -1019,7 +1031,6 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
                 getExtensions().add(ext);
             }
         }
-        
     }
 
 }

--- a/src/main/java/org/jenkinsci/plugins/ghprb/jobdsl/GhprbContextExtensionPoint.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/jobdsl/GhprbContextExtensionPoint.java
@@ -38,6 +38,7 @@ public class GhprbContextExtensionPoint extends ContextExtensionPoint {
                 null,
                 null,
                 null,
+                null,
                 context.extensionContext.extensions
         );
     }

--- a/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/config.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/config.groovy
@@ -36,6 +36,9 @@ f.advanced() {
   f.entry(field: "orgslist", title: _("List of organizations. Their members will be whitelisted.")) {
     f.textarea() 
   }
+  f.entry(field: "labelslist", title: _("List of github labels for which the build should not be triggered.")) {
+    f.textarea()
+  }
   f.entry(field: "allowMembersOfWhitelistedOrgsAsAdmin", title: "Allow members of whitelisted organizations as admins") {
     f.checkbox() 
   }

--- a/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/global.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/ghprb/GhprbTrigger/global.groovy
@@ -43,6 +43,9 @@ f.section(title: descriptor.displayName) {
     f.entry(field: "cron", title: _("Crontab line"), help: "/descriptor/hudson.triggers.TimerTrigger/help/spec") {
       f.textbox(default: "H/5 * * * *", checkUrl: "'descriptorByName/hudson.triggers.TimerTrigger/checkSpec?value=' + encodeURIComponent(this.value)") 
     }
+    f.entry(field: "labelslist", title: _("List of github labels for which the build should not be triggered.")) {
+      f.textarea()
+    }
   }
   f.entry(title: _("Application Setup")) {
     f.hetero_list(items: descriptor.extensions, name: "extensions", oneEach: "true", hasHeader: "true", descriptors: descriptor.getGlobalExtensionDescriptors()) 

--- a/src/test/java/org/jenkinsci/plugins/ghprb/GhprbRepositoryTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GhprbRepositoryTest.java
@@ -1,6 +1,7 @@
 package org.jenkinsci.plugins.ghprb;
 
 import org.apache.commons.codec.binary.Hex;
+import org.fest.util.Collections;
 import org.jenkinsci.plugins.ghprb.extensions.status.GhprbSimpleStatus;
 import org.joda.time.DateTime;
 import org.junit.Assert;
@@ -40,7 +41,9 @@ import java.net.URL;
 import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
@@ -211,7 +214,6 @@ public class GhprbRepositoryTest {
         verify(ghPullRequest, times(1)).getCreatedAt();
         verify(ghPullRequest, times(1)).getUser();
         verify(ghPullRequest, times(1)).getBase();
-        verify(ghPullRequest, times(1)).getLabels();
         verifyNoMoreInteractions(ghPullRequest);
 
         verify(helper).ifOnlyTriggerPhrase();
@@ -253,6 +255,7 @@ public class GhprbRepositoryTest {
         given(helper.ifOnlyTriggerPhrase()).willReturn(false);
         given(helper.isWhitelisted(ghUser)).willReturn(true);
         given(helper.getTrigger()).willReturn(trigger);
+        given(helper.getLabels()).willReturn(Collections.set("bug", "help wanted"));
 
         // WHEN
         ghprbRepository.check();
@@ -335,6 +338,7 @@ public class GhprbRepositoryTest {
         given(helper.ifOnlyTriggerPhrase()).willReturn(false);
         given(helper.isWhitelisted(ghUser)).willReturn(true);
         given(helper.getTrigger()).willReturn(trigger);
+        given(helper.getLabels()).willReturn(Collections.set("bug", "help wanted"));
 
         // WHEN
         ghprbRepository.check(); // PR was created
@@ -428,6 +432,7 @@ public class GhprbRepositoryTest {
         given(helper.isRetestPhrase(eq("test this please"))).willReturn(true);
         given(helper.isWhitelisted(ghUser)).willReturn(true);
         given(helper.getTrigger()).willReturn(trigger);
+        given(helper.getLabels()).willReturn(Collections.set("bug", "help wanted"));
 
         // WHEN
         ghprbRepository.check(); // PR was created

--- a/src/test/java/org/jenkinsci/plugins/ghprb/GhprbRepositoryTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GhprbRepositoryTest.java
@@ -211,12 +211,14 @@ public class GhprbRepositoryTest {
         verify(ghPullRequest, times(1)).getCreatedAt();
         verify(ghPullRequest, times(1)).getUser();
         verify(ghPullRequest, times(1)).getBase();
+        verify(ghPullRequest, times(1)).getLabels();
         verifyNoMoreInteractions(ghPullRequest);
 
         verify(helper).ifOnlyTriggerPhrase();
         verify(helper).getWhiteListTargetBranches();
         verify(helper, times(2)).isProjectDisabled();
         verify(helper).checkSkipBuild(eq(ghPullRequest));
+        verify(helper, times(1)).getLabels();
         verifyNoMoreInteractions(helper);
         verifyNoMoreInteractions(gt);
 
@@ -278,6 +280,7 @@ public class GhprbRepositoryTest {
         verify(ghPullRequest, times(1)).listCommits();
         verify(ghPullRequest, times(1)).getBody();
         verify(ghPullRequest, times(1)).getId();
+        verify(ghPullRequest, times(2)).getLabels();
         verifyNoMoreInteractions(ghPullRequest);
 
         verify(helper, times(1)).isWhitelisted(eq(ghUser)); // Call to Github API
@@ -286,6 +289,7 @@ public class GhprbRepositoryTest {
         verify(helper, times(2)).getWhiteListTargetBranches();
         verify(helper, times(4)).isProjectDisabled();
         verify(helper, times(2)).checkSkipBuild(eq(ghPullRequest));
+        verify(helper, times(2)).getLabels();
         verifyNoMoreInteractions(helper);
 
         verify(ghUser, times(1)).getEmail(); // Call to Github API
@@ -363,12 +367,14 @@ public class GhprbRepositoryTest {
         verify(ghPullRequest, times(1)).listCommits();
         verify(ghPullRequest, times(1)).getBody();
         verify(ghPullRequest, times(1)).getId();
+        verify(ghPullRequest, times(2)).getLabels();
         verifyNoMoreInteractions(ghPullRequest);
 
         verify(helper, times(1)).isWhitelisted(eq(ghUser)); // Call to Github API
         verify(helper, times(2)).ifOnlyTriggerPhrase();
         verify(helper, times(1)).getBuilds();
         verify(helper, times(2)).getWhiteListTargetBranches();
+        verify(helper, times(2)).getLabels();
 
         // verify(helper).isBotUser(eq(ghUser));
         verify(helper).isWhitelistPhrase(eq("comment body"));
@@ -451,6 +457,7 @@ public class GhprbRepositoryTest {
         verify(ghPullRequest, times(2)).getUpdatedAt();
         verify(ghPullRequest, times(1)).getCreatedAt();
         verify(ghPullRequest, times(2)).getHtmlUrl();
+        verify(ghPullRequest, times(2)).getLabels();
 
         verify(ghPullRequest, times(1)).getId();
         verify(ghPullRequest, times(1)).getComments();
@@ -463,6 +470,7 @@ public class GhprbRepositoryTest {
         verify(helper, times(2)).ifOnlyTriggerPhrase();
         verify(helper, times(2)).getBuilds();
         verify(helper, times(2)).getWhiteListTargetBranches();
+        verify(helper, times(2)).getLabels();
 
         verify(helper).isWhitelistPhrase(eq("test this please"));
         verify(helper).isOktotestPhrase(eq("test this please"));

--- a/src/test/java/org/jenkinsci/plugins/ghprb/GhprbTestUtil.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GhprbTestUtil.java
@@ -318,7 +318,8 @@ public class GhprbTestUtil {
         jsonObject.put("msgSuccess", "Success");
         jsonObject.put("msgFailure", "Failure");
         jsonObject.put("commitStatusContext", "Status Context");
-        
+        jsonObject.put("labelslist", "in progress");
+
         JSONObject githubAuth = new JSONObject();
         githubAuth.put("credentialsId", getCredentialsId());
         githubAuth.put("serverAPIUrl", apiUrl);


### PR DESCRIPTION
Adds a configuration which allows to configure github labels that, if present on the pull request, will skip the build. This is useful when working on a pull request that is still in progress, and you don't want commits to trigger a build.