### PR TITLE
Provide default value for requestForTestingPhrase

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
@@ -629,6 +629,7 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
          * value in the global.jelly file as this value is dynamic and will not be
          * retained once configure() is called.
          */
+        private String requestForTestingPhrase = "Can one of the admins verify this patch?";
         private String whitelistPhrase = ".*add\\W+to\\W+whitelist.*";
         private String okToTestPhrase = ".*ok\\W+to\\W+test.*";
         private String retestPhrase = ".*test\\W+this\\W+please.*";
@@ -678,8 +679,6 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
         
         private String adminlist;
         
-        private String requestForTestingPhrase;
-
         // map of jobs (by their fullName) and their map of pull requests
         private transient Map<String, Map<Integer, GhprbPullRequest>> jobs;
         


### PR DESCRIPTION
I configure my Jenkinses via a setup.groovy script and never visit the configuration page.

Builds are never run for people who are not on the white list and the admin is never asked to approve builds for them.

It turns out that the reason is that Jenkins is trying to use the `requestForTesting` phrase but that it has never been set, leading to a `NullPointerException`:

```
Unable to handle comment for PR# 1213, repo: git-workshop/git-workshop.<elided>
java.lang.NullPointerException
	at org.jenkinsci.plugins.ghprb.GhprbRepository.addComment(GhprbRepository.java:238)
	at org.jenkinsci.plugins.ghprb.GhprbRepository.addComment(GhprbRepository.java:234)
	at org.jenkinsci.plugins.ghprb.GhprbPullRequest.<init>(GhprbPullRequest.java:139)
	at org.jenkinsci.plugins.ghprb.GhprbRepository.getPullRequest(GhprbRepository.java:365)
	at org.jenkinsci.plugins.ghprb.GhprbRepository.onIssueCommentHook(GhprbRepository.java:345)
	at org.jenkinsci.plugins.ghprb.GhprbTrigger.handleComment(GhprbTrigger.java:611)
	at org.jenkinsci.plugins.ghprb.GhprbRootAction$1.run(GhprbRootAction.java:233)
```

I'm currently working around the issue like so:

```groovy
// Set up the Github Pull Request Builder Plugin
//    https://gist.github.com/kpettijohn/e294c50e29ca4e8a329e
def ghprbDesc = Jenkins.instance.getDescriptorByType(org.jenkinsci.plugins.ghprb.GhprbTrigger.DescriptorImpl.class)

// [other settings elided]
// Set a value to use when Jenkins asks the admins if it's
// ok to run a build from a "stranger".  This field has no
// default value, so if it's not set here, Jenkins accesses a
// null pointer and becomes sad.
Field testPlease = ghprbDesc.class.getDeclaredField("requestForTestingPhrase")
testPlease.setAccessible(true)
testPlease.set(ghprbDesc, "Can one of the admins verify this patch?")
```

but it seems like it would be safer to provide it with a default value like you do for the other phrases.

Alternatively, `org.jenkinsci.plugins.ghprb.GhprbRepository.addComment` {sh,c}ould check that it's argument is not null before using it.  **But**, that wouldn't help the 'infrastructure as code' crowd as much as my proposed change.

It would be really nice if there were a programmatic way to configure the plugin.  The `configure` method is tied to a request, so it's not easily usable and using reflection to access the plugin's private bits seems icky.